### PR TITLE
Fix source-url issue

### DIFF
--- a/evernote-sdk-ios/ENSDK/ENNote.m
+++ b/evernote-sdk-ios/ENSDK/ENNote.m
@@ -167,6 +167,13 @@
             NSString * extension = [ENMIMEUtils fileExtensionForMIMEType:resource.mimeType];
             NSString * fakeUrl = [NSString stringWithFormat:@"http://example.com/%@.%@", dataHash, extension];
             edamResource.attributes.sourceURL = fakeUrl;
+        } else {
+            edamResource.attributes.sourceURL = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
+                                                                                                                     kCFAllocatorDefault,
+                                                                                                                     (CFStringRef)edamResource.attributes.sourceURL,
+                                                                                                                     NULL,
+                                                                                                                     CFSTR(":/?#[]@!$&'()*+,;="),
+                                                                                                                     kCFStringEncodingUTF8));
         }
         [edamResources addObject:edamResource];
     }


### PR DESCRIPTION
Sometimes, source-url of EDAMResource contains 2byte characters and special characters.
To Avoid crash, convert source-url string to URL-encode string.
