### PR TITLE
Exposed Class Method to create ENNoteContent object using ENML. Also add...

### DIFF
--- a/evernote-sdk-ios/ENSDK/ENNoteContent.h
+++ b/evernote-sdk-ios/ENSDK/ENNoteContent.h
@@ -55,4 +55,22 @@
  *  @return A valid note content instance.
  */
 + (instancetype)noteContentWithSanitizedHTML:(NSString *)html;
+
+/**
+ *  Class method to create a note content object from an ENML string.
+ *
+ *  @param string An EMML string.
+ *
+ *  @return A valid note content instance.
+ */
++ (instancetype)noteContentWithENML:(NSString *)enml;
+
+/**
+ *  Instance getter method for retrieving the receiver's ENML.
+ *
+ *
+ *  @return Vaid ENML in NSString format.
+ */
+- (NSString *)enml;
+
 @end


### PR DESCRIPTION
I found utility in having both of these methods exposed when trying to add resources to a note that was generated from sanitized HTML. Consider the following code:

``` obj-c
NSString *enmlTagString = @"<en-media type=\"text/x-vcard\" hash=\"%@\" />";
    note.title = [messageParams objectForKey:@"subject"];
    note.content = [ENNoteContent noteContentWithSanitizedHTML:renderedHTML];

    //insert the en-media tags right before we close the enml
    NSMutableString *content = [NSMutableString stringWithString:note.content.enml];
    NSRange index = [note.content.enml rangeOfString:@"</en-note>"];
    [content insertString:enMediaString atIndex:index.location];
    note.content = [ENNoteContent noteContentWithENML:content];
```

If I try and add resources **not** using this method, the attachments never show-up in the resulting note (due to how the HTML is rendered into ENML?). Therefore, having the ability to directly edit the ENML allows me to insert resource links along with my HTML.

Thank you!
