### PR TITLE
Add support for shared authentication in App Extension

### DIFF
--- a/evernote-sdk-ios/ENSDK/Advanced/ENPreferencesStore.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENPreferencesStore.m
@@ -29,6 +29,8 @@
 #import "ENPreferencesStore.h"
 #import "ENSDKPrivate.h"
 
+static NSString * ENPreferencesStoreFilename = @"com.evernote.evernote-sdk-ios.plist";
+
 @interface ENPreferencesStore ()
 @property (nonatomic, strong) NSString * pathname;
 @property (nonatomic, strong) NSMutableDictionary * store;
@@ -51,10 +53,31 @@
     return self;
 }
 
+- (id)initWithURL:(NSURL*)fileURL
+{
+    self = [super init];
+    if (self) {
+        self.pathname = [fileURL path];
+        [self load];
+    }
+    return self;
+}
+
 - (id)init
 {
     [NSException raise:NSInvalidArgumentException format:@"Must call -initWithStoreFilename:"];
     return nil;
+}
+
++(instancetype) preferenceStoreWithSecurityApplicationGroupIdentifier:(NSString*)groupId
+{
+    NSURL* URL = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupId];
+    return [[self alloc] initWithURL:[URL URLByAppendingPathComponent:ENPreferencesStoreFilename]];
+}
+
++(instancetype) defaultPreferenceStore
+{
+    return [[self alloc] initWithStoreFilename:ENPreferencesStoreFilename];
 }
 
 - (id)objectForKey:(NSString *)key

--- a/evernote-sdk-ios/ENSDK/Advanced/ENSDKAdvanced.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENSDKAdvanced.h
@@ -218,3 +218,11 @@
  */
 @property (nonatomic, readonly) NSString * guid;
 @end
+
+@interface ENPreferencesStore (Advanced)
+
++(instancetype) defaultPreferenceStore;
+
++(instancetype) preferenceStoreWithSecurityApplicationGroupIdentifier:(NSString*)groupId;
+
+@end

--- a/evernote-sdk-ios/ENSDK/Advanced/ENSDKAdvanced.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENSDKAdvanced.h
@@ -122,6 +122,22 @@
  *  @return A client for the note store that contains the notebook.
  */
 - (ENNoteStoreClient *)noteStoreForNotebook:(ENNotebook *)notebook;
+
+/**
+ *  Set to the security application group identifier, if the app should share authenticate with an application group.
+ *
+ *  @param the security application group identifier.
+ *  @see https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW6
+ */
++ (void) setSecurityApplicationGroupIdentifier:(NSString*)securityApplicationGroupIdentifier;
+
+/**
+ *  The keychain groups used for keychain sharing. If not set, keychain sharing is disabled.
+ *
+ *  This should be the shared keychain group of your app in XCode "Capabilities" > "Keychain Sharing".
+ */
++ (void) setKeychainGroup:(NSString*)keychainGroup;
+
 @end
 
 @interface ENSessionFindNotesResult (Advanced)

--- a/evernote-sdk-ios/ENSDK/ENSession.h
+++ b/evernote-sdk-ios/ENSDK/ENSession.h
@@ -258,6 +258,14 @@ typedef NS_OPTIONS(NSUInteger, ENSessionSortOrder) {
  */
 + (void)setDisableRefreshingNotebooksCacheOnLaunch:(BOOL)disable;
 
+/**
+ *  Set to the security application group identifier, if the app should share authenticate with an application group.
+ *
+ *  @param the security application group identifier.
+ *  @see https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW6
+ */
++ (void) setSecurityApplicationGroupIdentifier:(NSString*)securityApplicationGroupIdentifier;
+
 #pragma mark - Authentication
 
 /**

--- a/evernote-sdk-ios/ENSDK/ENSession.h
+++ b/evernote-sdk-ios/ENSDK/ENSession.h
@@ -258,21 +258,6 @@ typedef NS_OPTIONS(NSUInteger, ENSessionSortOrder) {
  */
 + (void)setDisableRefreshingNotebooksCacheOnLaunch:(BOOL)disable;
 
-/**
- *  Set to the security application group identifier, if the app should share authenticate with an application group.
- *
- *  @param the security application group identifier.
- *  @see https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW6
- */
-+ (void) setSecurityApplicationGroupIdentifier:(NSString*)securityApplicationGroupIdentifier;
-
-/**
- *  The keychain groups used for keychain sharing. If not set, keychain sharing is disabled.
- *
- *  This should be the shared keychain group of your app in XCode "Capabilities" > "Keychain Sharing".
- */
-+ (void) setKeychainGroup:(NSString*)keychainGroup;
-
 #pragma mark - Authentication
 
 /**

--- a/evernote-sdk-ios/ENSDK/ENSession.h
+++ b/evernote-sdk-ios/ENSDK/ENSession.h
@@ -266,6 +266,13 @@ typedef NS_OPTIONS(NSUInteger, ENSessionSortOrder) {
  */
 + (void) setSecurityApplicationGroupIdentifier:(NSString*)securityApplicationGroupIdentifier;
 
+/**
+ *  The keychain groups used for keychain sharing. If not set, keychain sharing is disabled.
+ *
+ *  This should be the shared keychain group of your app in XCode "Capabilities" > "Keychain Sharing".
+ */
++ (void) setKeychainGroup:(NSString*)keychainGroup;
+
 #pragma mark - Authentication
 
 /**

--- a/evernote-sdk-ios/ENSDK/ENSession.m
+++ b/evernote-sdk-ios/ENSDK/ENSession.m
@@ -50,7 +50,6 @@ NSString * const ENSessionDidUnauthenticateNotification = @"ENSessionDidUnauthen
 static NSString * ENSessionBootstrapServerBaseURLStringCN  = @"app.yinxiang.com";
 static NSString * ENSessionBootstrapServerBaseURLStringUS  = @"www.evernote.com";
 
-static NSString * ENSessionPreferencesFilename = @"com.evernote.evernote-sdk-ios.plist";
 static NSString * ENSessionPreferencesCredentialStore = @"CredentialStore";
 static NSString * ENSessionPreferencesCurrentProfileName = @"CurrentProfileName";
 static NSString * ENSessionPreferencesUser = @"User";
@@ -141,6 +140,7 @@ static NSUInteger ENSessionNotebooksCacheValidity = (5 * 60);   // 5 minutes
 static NSString * SessionHostOverride;
 static NSString * ConsumerKey, * ConsumerSecret;
 static NSString * DeveloperToken, * NoteStoreUrl;
+static NSString * SecurityApplicationGroupIdentifier;
 static BOOL disableRefreshingNotebooksCacheOnLaunch;
 
 + (void)setSharedSessionConsumerKey:(NSString *)key
@@ -178,6 +178,11 @@ static BOOL disableRefreshingNotebooksCacheOnLaunch;
 + (void)setDisableRefreshingNotebooksCacheOnLaunch:(BOOL)disable
 {
     disableRefreshingNotebooksCacheOnLaunch = disable;
+}
+
++ (void) setSecurityApplicationGroupIdentifier:(NSString*)securityApplicationGroupIdentifier
+{
+    SecurityApplicationGroupIdentifier = securityApplicationGroupIdentifier;
 }
 
 + (BOOL)checkSharedSessionSettings
@@ -225,7 +230,7 @@ static BOOL disableRefreshingNotebooksCacheOnLaunch;
 - (void)startup
 {
     self.logger = [[ENSessionDefaultLogger alloc] init];
-    self.preferences = [[ENPreferencesStore alloc] initWithStoreFilename:ENSessionPreferencesFilename];
+    self.preferences = SecurityApplicationGroupIdentifier ? [ENPreferencesStore preferenceStoreWithSecurityApplicationGroupIdentifier:SecurityApplicationGroupIdentifier] : [ENPreferencesStore defaultPreferenceStore];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(storeClientFailedAuthentication:)

--- a/evernote-sdk-ios/ENSDK/Private/ENCredentials.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENCredentials.m
@@ -76,10 +76,11 @@ authenticationResult:(EDAMAuthenticationResult *)authenticationResult
 {
     // auth token gets saved to the keychain
     NSError *error;
-    BOOL success = [SSKeychain setPassword:_authenticationToken
-                                forService:self.host
-                                   account:self.edamUserId 
-                                     error:&error];
+
+    SSKeychainQuery *query = [self keychainQuery];
+    query.password = _authenticationToken;
+
+    BOOL success = [query save:&error];
     if (!success) {
         NSLog(@"Error saving to keychain: %@ %ld", error, (long)error.code);
         return NO;
@@ -89,13 +90,16 @@ authenticationResult:(EDAMAuthenticationResult *)authenticationResult
 
 - (void)deleteFromKeychain
 {
-    [SSKeychain deletePasswordForService:self.host account:self.edamUserId];
+    [[self keychainQuery] deleteItem:nil];
 }
 
 - (NSString *)authenticationToken
 {
     NSError *error;
-    NSString *token = [SSKeychain passwordForService:self.host account:self.edamUserId error:&error];
+    SSKeychainQuery* query = [self keychainQuery];
+    [query fetch:&error];
+
+    NSString *token = [query password];
     if (!token) {
         NSLog(@"Error getting password from keychain: %@", error);
     }
@@ -116,6 +120,16 @@ authenticationResult:(EDAMAuthenticationResult *)authenticationResult
     }
     
     return YES;
+}
+
+#pragma mark - SSKeyChain Helpers
+
+-(SSKeychainQuery*) keychainQuery
+{
+    SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
+    query.service = self.host;
+    query.account = self.edamUserId;
+    return query;
 }
 
 #pragma mark - NSCoding

--- a/evernote-sdk-ios/ENSDK/Private/ENCredentials.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENCredentials.m
@@ -27,6 +27,8 @@
  */
 
 #import "ENCredentials.h"
+#import "ENSession.h"
+#import "ENSDKPrivate.h"
 #import "SSKeychain.h"
 
 @interface ENCredentials()
@@ -129,6 +131,9 @@ authenticationResult:(EDAMAuthenticationResult *)authenticationResult
     SSKeychainQuery *query = [[SSKeychainQuery alloc] init];
     query.service = self.host;
     query.account = self.edamUserId;
+    if ([ENSession keychainAccessGroup]) {
+        query.accessGroup = [ENSession keychainAccessGroup];
+    }
     return query;
 }
 

--- a/evernote-sdk-ios/ENSDK/Private/ENSDKPrivate.h
+++ b/evernote-sdk-ios/ENSDK/Private/ENSDKPrivate.h
@@ -38,6 +38,7 @@ extern NSString * const ENBootstrapProfileNameChina;
 
 @interface ENSession (Private)
 @property (nonatomic, readonly) EDAMUserID userID;
++(NSString*) keychainAccessGroup;
 @end
 
 @interface ENNotebook (Private)


### PR DESCRIPTION
As discussed in #72, this patch implemented following:

- method to configure App Group from ENSession
- method to configure Keychain group from ENSession
- options to create ENPreferenceStore under shared container path
- use ENPreferenceStore from shared container path if it is configured 
- use shared keychain group if keychain group is configured

To share authentication between app and extension, both security application group id (``[ENSession setSecurityApplicationGroupIdentifier:]``) and keychain group (``[ENSession setKeychainGroup:]``) should be set. Obviously, user have to authenticate from the main app before they can use the login from app extension.