### PR TITLE
Updated Getting Started Instructions

### DIFF
--- a/Getting_Started.md
+++ b/Getting_Started.md
@@ -68,6 +68,10 @@ Users will have the fastest OAuth experience in your app if they already have th
 			</array>
 		</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>en</string>
+	</array>
 
 Don't worry: authentication can still proceed if the Evernote app is not installed, but it will fall back to web-based OAuth. This is transparent to your app.
 


### PR DESCRIPTION
iOS 9 requires that apps register which URL schemes they'll
query. This updates the Getting Started instructions to tell
consuming clients to declare that they'll ask that Evernote is
installed.

This will fix issues with detecting that Evernote is installed
and allow the native UI to be used.