### PR TITLE
Removed xml includes from public headers

### DIFF
--- a/evernote-sdk-ios/ENSDK/Advanced/Utilities/ENMLWriter/ENXMLUtils.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/Utilities/ENMLWriter/ENXMLUtils.h
@@ -27,7 +27,8 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <libxml/xmlstring.h>
+
+typedef unsigned char xmlChar;
 
 static inline NSString * NSStringFromXmlCharWithLength( const xmlChar * ch, size_t length) {
   if (ch == NULL) {

--- a/evernote-sdk-ios/ENSDK/Private/ENXMLSaxParser.h
+++ b/evernote-sdk-ios/ENSDK/Private/ENXMLSaxParser.h
@@ -27,7 +27,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <libxml/tree.h>
+
+typedef struct _xmlParserCtxt xmlParserCtxt;
+typedef xmlParserCtxt *xmlParserCtxtPtr;
 
 extern NSString * const ENXMLSaxParserErrorDomain;
 

--- a/evernote-sdk-ios/ENSDK/Private/ENXMLSaxParser.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENXMLSaxParser.m
@@ -31,6 +31,7 @@
 #import "ENXMLDTD.h"
 #import "ENXMLUtils.h"
 
+#import <libxml/tree.h>
 #include <libxml/HTMLtree.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This should fix issues with the "include non-modular header" error when
compiling for Swift. (#113)