### PR TITLE
Chinese localisation fix

### DIFF
--- a/evernote-sdk-ios/ENSDK/ENSession.m
+++ b/evernote-sdk-ios/ENSDK/ENSession.m
@@ -298,7 +298,7 @@ static BOOL disableRefreshingNotebooksCacheOnLaunch;
     } else {
         // Choose the initial host based on locale. Simplified Chinese locales get the yinxiang service.
         NSString * locale = [[[NSLocale currentLocale] localeIdentifier] lowercaseString];
-        if ([locale hasPrefix:@"zh_hans"] || [locale isEqualToString:@"zh_cn"] || [locale isEqualToString:@"zh"]) {
+        if ([locale hasPrefix:@"zh-hans"] || [locale isEqualToString:@"zh-cn"] || [locale isEqualToString:@"zh"]) {
             self.sessionHost = ENSessionBootstrapServerBaseURLStringCN;
         } else {
             self.sessionHost = ENSessionBootstrapServerBaseURLStringUS;


### PR DESCRIPTION
According to https://developer.apple.com/library/ios/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html the correct locale is `zh-hans` & `zh-cn` with a hyphen and not an underscore. My device also returned `ZH-Hans`.
