### PR TITLE
Fix crash when encountering empty tag values

### DIFF
--- a/evernote-sdk-ios/ENSDK/Advanced/Utilities/ENMLWriter/ENXMLWriter.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/Utilities/ENMLWriter/ENXMLWriter.m
@@ -179,8 +179,10 @@ static int ENXMLWriter_delegateCloseCallback(void * context) {
   if (success == NO) return NO;
   
   for (NSString *key in [attrDict allKeys]) {
-    [self writeAttributeName:key 
-                       value:[attrDict objectForKey:key]];
+    id value = attrDict[key];
+    if ([value isKindOfClass:[NSString class]]) {
+      [self writeAttributeName:key value:value];
+    }
   }
   
   return YES;


### PR DESCRIPTION
When encountering an empty tag the HTML to ENML converter crashes.
This PR only will write tags that have a NSString value.