### PR TITLE
Add Resource detection in ENSessionFindNotesResult.  

### DIFF
--- a/evernote-sdk-ios/ENSDK/ENSession.h
+++ b/evernote-sdk-ios/ENSDK/ENSession.h
@@ -148,6 +148,7 @@ typedef NS_OPTIONS(NSUInteger, ENSessionSortOrder) {
 @property (nonatomic, strong, nullable) NSString * title;
 @property (nonatomic, strong, nullable) NSDate * created;
 @property (nonatomic, strong, nullable) NSDate * updated;
+@property (nonatomic) BOOL hasResources;
 @end
 
 /**

--- a/evernote-sdk-ios/ENSDK/ENSession.m
+++ b/evernote-sdk-ios/ENSDK/ENSession.m
@@ -1217,7 +1217,8 @@ static BOOL disableRefreshingNotebooksCacheOnLaunch;
     resultSpec.includeCreated = @YES;
     resultSpec.includeUpdated = @YES;
     resultSpec.includeUpdateSequenceNum = @YES;
-    
+    resultSpec.includeLargestResourceSize = @YES;
+
     EDAMNoteFilter * noteFilter = [[EDAMNoteFilter alloc] init];
     noteFilter.words = noteSearch.searchString;
     
@@ -1484,7 +1485,8 @@ static BOOL disableRefreshingNotebooksCacheOnLaunch;
         result.created = [NSDate dateWithEDAMTimestamp:[metadata.created longLongValue]];
         result.updated = [NSDate dateWithEDAMTimestamp:[metadata.updated longLongValue]];
         result.updateSequenceNum = [metadata.updateSequenceNum intValue];
-        
+        result.hasResources = (metadata.largestResourceSize > 0)?YES:NO;
+
         [findNotesResults addObject:result];
         
         // If the caller specified a max result count, and we've reached it, then stop fixing up


### PR DESCRIPTION
This will help to find if there are any resources in the note while searching (no need to download the note to know such answer).