### PR TITLE
Fix Chinese Simplified  localisation bug

### DIFF
--- a/evernote-sdk-ios/ENSDK/ENSession.m
+++ b/evernote-sdk-ios/ENSDK/ENSession.m
@@ -299,7 +299,7 @@ static BOOL disableRefreshingNotebooksCacheOnLaunch;
     } else {
         // Choose the initial host based on locale. Simplified Chinese locales get the yinxiang service.
         NSString * locale = [[[NSLocale currentLocale] localeIdentifier] lowercaseString];
-        if ([locale hasPrefix:@"zh-hans"] || [locale isEqualToString:@"zh-cn"] || [locale isEqualToString:@"zh"]) {
+        if ([locale hasPrefix:@"zh-hans"] || [locale isEqualToString:@"zh-cn"] || [locale isEqualToString:@"zh"]|| [locale isEqualToString:@"zh_cn"]) {
             self.sessionHost = ENSessionBootstrapServerBaseURLStringCN;
         } else {
             self.sessionHost = ENSessionBootstrapServerBaseURLStringUS;


### PR DESCRIPTION
Fix Chinese Simplified  localisation bug
In Chinese the locale is ‘zh_CN’ no ‘zh-CN’