### PR TITLE
Fixed warnings for functions and blocks with no parameters

### DIFF
--- a/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.h
@@ -962,7 +962,7 @@ DEPRECATED_MSG_ATTRIBUTE("Use -createTag:completion: instead") NS_SWIFT_UNAVAILA
 DEPRECATED_MSG_ATTRIBUTE("Use -updateTag:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 - (void)untagAllWithGuid:(EDAMGuid)guid
-                 success:(void(^)())success
+                 success:(void(^)(void))success
                  failure:(void(^)(NSError *error))failure
 DEPRECATED_MSG_ATTRIBUTE("Use -untagAllWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
@@ -1256,7 +1256,7 @@ DEPRECATED_MSG_ATTRIBUTE("Use -authenticateToSharedNotebook:completion: instead"
 DEPRECATED_MSG_ATTRIBUTE("Use -getSharedNotebookByAuthWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 - (void)emailNoteWithParameters:(EDAMNoteEmailParameters *)parameters
-                        success:(void(^)())success
+                        success:(void(^)(void))success
                         failure:(void(^)(NSError *error))failure
 DEPRECATED_MSG_ATTRIBUTE("Use -emailNoteWithParameters:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
@@ -1266,7 +1266,7 @@ DEPRECATED_MSG_ATTRIBUTE("Use -emailNoteWithParameters:completion: instead") NS_
 DEPRECATED_MSG_ATTRIBUTE("Use -shareNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 - (void)stopSharingNoteWithGuid:(EDAMGuid)guid
-                        success:(void(^)())success
+                        success:(void(^)(void))success
                         failure:(void(^)(NSError *error))failure
 DEPRECATED_MSG_ATTRIBUTE("Use -stopSharingNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 

--- a/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.m
@@ -1023,7 +1023,7 @@
 }
 
 - (void)untagAllWithGuid:(EDAMGuid)guid
-                 success:(void(^)())success
+                 success:(void(^)(void))success
                  failure:(void(^)(NSError *error))failure
 {
     [self untagAllWithGuid:guid completion:^(NSError * _Nonnull error) {
@@ -1569,7 +1569,7 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
 }
 
 - (void)emailNoteWithParameters:(EDAMNoteEmailParameters *)parameters
-                        success:(void(^)())success
+                        success:(void(^)(void))success
                         failure:(void(^)(NSError *error))failure
 {
     [self emailNoteWithParameters:parameters completion:^(NSError * _Nonnull error) {
@@ -1587,7 +1587,7 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
 }
 
 - (void)stopSharingNoteWithGuid:(EDAMGuid)guid
-                        success:(void(^)())success
+                        success:(void(^)(void))success
                         failure:(void(^)(NSError *error))failure
 {
     [self stopSharingNoteWithGuid:guid completion:^(NSError * _Nonnull error) {

--- a/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.h
@@ -150,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
     DEPRECATED_MSG_ATTRIBUTE("Use -authenticateToBusinessWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 - (void)revokeLongSessionWithAuthenticationToken:(NSString*)authenticationToken
-                                         success:(void(^)())success
+                                         success:(void(^)(void))success
                                          failure:(void(^)(NSError *error))failure
 	DEPRECATED_MSG_ATTRIBUTE("Use -revokeLongSessionWithAuthenticationToken:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 @end

--- a/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.m
@@ -192,7 +192,7 @@
 }
 
 - (void)revokeLongSessionWithAuthenticationToken:(NSString*)authenticationToken
-                                         success:(void(^)())success
+                                         success:(void(^)(void))success
                                          failure:(void(^)(NSError *error))failure {
     [self revokeLongSessionWithAuthenticationToken:authenticationToken completion:^(NSError *error) {
         (error == nil) ? success() : failure(error);

--- a/evernote-sdk-ios/ENSDK/ENCommonUtils.h
+++ b/evernote-sdk-ios/ENSDK/ENCommonUtils.h
@@ -10,7 +10,7 @@
 
 @interface ENCommonUtils : NSObject
 
-BOOL IsIOS8();
-BOOL IsEvernoteInstalled();
+BOOL IsIOS8(void);
+BOOL IsEvernoteInstalled(void);
 
 @end

--- a/evernote-sdk-ios/ENSDK/Private/ENStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Private/ENStoreClient.h
@@ -35,9 +35,9 @@ extern NSString * ENStoreClientDidFailWithAuthenticationErrorNotification;
 
 @interface ENStoreClient : NSObject
 
-- (void)invokeAsyncBoolBlock:(BOOL(^)())block completion:(void (^)(BOOL value, NSError *_Nullable error))completion;
+- (void)invokeAsyncBoolBlock:(BOOL(^)(void))block completion:(void (^)(BOOL value, NSError *_Nullable error))completion;
 - (void)invokeAsyncObjectBlock:(nullable id(^)())block completion:(void (^)(id _Nullable value, NSError *_Nullable error))completion;
-- (void)invokeAsyncInt32Block:(int32_t(^)())block completion:(void (^)(int32_t value, NSError *_Nullable error))completion;
+- (void)invokeAsyncInt32Block:(int32_t(^)(void))block completion:(void (^)(int32_t value, NSError *_Nullable error))completion;
 - (void)invokeAsyncBlock:(void(^)())block completion:(void (^)(NSError *_Nullable error))completion;
 
 @end

--- a/evernote-sdk-ios/ENSDK/Private/ENStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENStoreClient.m
@@ -50,7 +50,7 @@ NSString * ENStoreClientDidFailWithAuthenticationErrorNotification = @"ENStoreCl
     return self;
 }
 
-- (void)invokeAsyncBoolBlock:(BOOL(^)())block completion:(void (^)(BOOL val, NSError *error))completion
+- (void)invokeAsyncBoolBlock:(BOOL(^)(void))block completion:(void (^)(BOOL val, NSError *error))completion
 {
     dispatch_async(self.queue, ^(void) {
         __block BOOL retVal = NO;
@@ -68,7 +68,7 @@ NSString * ENStoreClientDidFailWithAuthenticationErrorNotification = @"ENStoreCl
     });
 }
 
-- (void)invokeAsyncInt32Block:(int32_t(^)())block completion:(void (^)(int32_t val, NSError *_Nullable error))completion
+- (void)invokeAsyncInt32Block:(int32_t(^)(void))block completion:(void (^)(int32_t val, NSError *_Nullable error))completion
 {
     dispatch_async(self.queue, ^(void) {
         __block int32_t retVal = -1;


### PR DESCRIPTION
The SDK _has several warnings_ linked to the declaration of fuction and block with no parameters.

This error occurs when you try to declare a function with no arguments, and compile with -`Werror=strict-prototypes`, as follows:

`int foo();`

Fix it by declare it as

`int foo(void);`

**This is because in c,** foo(void) takes no arguments while foo() takes a infinite number of arguments.

The same, when **declaring blocks with no parameters**:

Fixed it by declaring it as

`void (^)(void)`
