### PR TITLE
Fix incorrect of usage of image assets in framework

### DIFF
--- a/evernote-sdk-ios/ENSDK/Private/ENNotebookCell.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENNotebookCell.m
@@ -44,7 +44,7 @@
         [self setSeparatorInset:UIEdgeInsetsMake(0.0, kCellInsetLeft, 0.0, 0.0)];
         self.checkButton = [[UIButton alloc] init];
         [self.contentView addSubview:self.checkButton];
-        [self.checkButton setImage:[[UIImage imageNamed:@"ENSDKResources.bundle/ENCheckIcon"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+        [self.checkButton setImage:[[UIImage imageNamed:@"ENSDKResources.bundle/ENCheckIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
         [self.checkButton sizeToFit];
         [self.checkButton setTintColor:[ENTheme defaultTintColor]];
         [self.checkButton setCenter:CGPointMake(0.6 * kCellInsetLeft, CGRectGetMidY(self.bounds) + 1.0)];

--- a/evernote-sdk-ios/ENSDK/Private/ENNotebookTypeView.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENNotebookTypeView.m
@@ -52,7 +52,7 @@ static CGFloat const kCircleRadius = 13;
 
 - (void)setIsBusiness:(BOOL)isBusiness {
     _isBusiness = isBusiness;
-    UIImage* notebookTypeIcon = isBusiness? [UIImage imageNamed:@"ENSDKResources.bundle/ENBusinessIcon"] : [UIImage imageNamed:@"ENSDKResources.bundle/ENMultiplePeopleIcon"];
+    UIImage* notebookTypeIcon = isBusiness? [UIImage imageNamed:@"ENSDKResources.bundle/ENBusinessIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil] : [UIImage imageNamed:@"ENSDKResources.bundle/ENMultiplePeopleIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
     _imageView.image = [notebookTypeIcon imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     [_imageView sizeToFit];
     [self updateNotebookTypeIconColor];

--- a/evernote-sdk-ios/ENSDK/SendToEvernoteActivity/ENNotebookPickerButton.m
+++ b/evernote-sdk-ios/ENSDK/SendToEvernoteActivity/ENNotebookPickerButton.m
@@ -48,7 +48,7 @@
         // Initialization code
         self.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
         
-        UIImage *dislosureImage = [[UIImage imageNamed:@"ENSDKResources.bundle/ENNextIcon"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        UIImage *dislosureImage = [[UIImage imageNamed:@"ENSDKResources.bundle/ENNextIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         self.discloureIndicator = [[UIImageView alloc] initWithImage:dislosureImage];
         [self.discloureIndicator setTintColor:[UIColor colorWithRed:0.8 green:0.8 blue:0.8 alpha:1]];
         
@@ -65,7 +65,7 @@
     if (_isBusinessNotebook == isBusinessNotebook) return;
     _isBusinessNotebook = isBusinessNotebook;
     if (_isBusinessNotebook) {
-        [self setImage:[[UIImage imageNamed:@"ENSDKResources.bundle/ENBusinessIcon"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+        [self setImage:[[UIImage imageNamed:@"ENSDKResources.bundle/ENBusinessIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
     } else {
         [self setImage:nil forState:UIControlStateNormal];
     }

--- a/evernote-sdk-ios/ENSDK/SendToEvernoteActivity/ENSaveToEvernoteActivity.m
+++ b/evernote-sdk-ios/ENSDK/SendToEvernoteActivity/ENSaveToEvernoteActivity.m
@@ -54,7 +54,7 @@
 
 - (UIImage *)activityImage
 {
-    return [UIImage imageNamed:@"ENSDKResources.bundle/ENActivityIcon"];
+    return [UIImage imageNamed:@"ENSDKResources.bundle/ENActivityIcon" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil];
 }
 
 - (BOOL)canPerformWithActivityItems:(NSArray *)activityItems


### PR DESCRIPTION
[UIImage imageNamed:@"xxx] doesn't work when EvernoteSDK.framework is embedded in app bundles because the framework is its own bundle. The correct usage is [[UIImage imageNamed:@"xxx" inBundle:frameworkBundle compatibleWithTraitCollection:nil].